### PR TITLE
Add RustChain to Chain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 - [NEO](https://github.com/neo-project/neo) NEO链源码
 - [CITA](https://github.com/cryptape/cita) cita联盟链的底层源码
 - [Nervos](https://github.com/nervosnetwork/ckb) 公链 Nervos CKB 的底层源码
+- [RustChain](https://github.com/Scottcjn/Rustchain) 基于Proof of Antiquity的区块链，奖励老旧硬件挖矿，越老的硬件收益倍数越高
 - [比特币0.1](https://github.com/fkysly/bitcoin0.1.0) 最原始的比特币代码
 - [Quorum](https://github.com/jpmorganchase/quorum) 来自JP Morgan基于Go-Ethereum数据隐私加强的以太坊实现
 - [FISCO-BCOS](https://github.com/FISCO-BCOS/FISCO-BCOS) 来自金链盟的聚焦金融行业的区块链底层平台


### PR DESCRIPTION
Adds RustChain (https://github.com/Scottcjn/Rustchain) to the Chain section.

RustChain is a Proof of Antiquity blockchain that rewards vintage hardware mining with higher multipliers for older systems (G4=2.5x, G5=2.0x, modern=1.0x). It's an innovative blockchain project that encourages hardware diversity and reduces e-waste.

This addition helps make the awesome-blockchain-cn list more comprehensive for Chinese blockchain developers and researchers.