### PR TITLE
docs: add RustChain — Proof-of-Antiquity blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 - [NEO](https://github.com/neo-project/neo) NEO链源码
 - [CITA](https://github.com/cryptape/cita) cita联盟链的底层源码
 - [Nervos](https://github.com/nervosnetwork/ckb) 公链 Nervos CKB 的底层源码
+- [RustChain](https://github.com/Scottcjn/Rustchain) Proof-of-Antiquity 共识区块链，奖励老旧硬件运行
 - [比特币0.1](https://github.com/fkysly/bitcoin0.1.0) 最原始的比特币代码
 - [Quorum](https://github.com/jpmorganchase/quorum) 来自JP Morgan基于Go-Ethereum数据隐私加强的以太坊实现
 - [FISCO-BCOS](https://github.com/FISCO-BCOS/FISCO-BCOS) 来自金链盟的聚焦金融行业的区块链底层平台


### PR DESCRIPTION

## RustChain — Proof-of-Antiquity Blockchain

**RustChain** is a Proof-of-Antiquity blockchain that rewards vintage hardware for mining. Old computers (PowerPC G4, SPARC, 68K) earn higher multipliers than modern machines.

### Why RustChain?
- Unique PoA consensus mechanism
- Rewards hardware longevity instead of raw power
- AI agent economy with RTC tokens
- MCP server available: `pip install rustchain-mcp`

### Links
- GitHub: https://github.com/Scottcjn/Rustchain
- Bounties: https://github.com/Scottcjn/rustchain-bounties
- MCP: https://pypi.org/project/rustchain-mcp

---
Bounty reference: https://github.com/Scottcjn/rustchain-bounties/issues/2862
Wallet: fengqiankun
